### PR TITLE
Add Ukraine-Moldova border experience blog post

### DIFF
--- a/index.html
+++ b/index.html
@@ -102,6 +102,7 @@
           <a class="btn btn-primary" href="mailto:philipp.kirr@gmail.com" data-de="Kontakt per E‑Mail" data-en="Contact via Email">Kontakt per E‑Mail</a>
           <a class="btn btn-ghost" href="https://www.linkedin.com/in/philipp-kirr-579274163" target="_blank" rel="noopener" data-de="LinkedIn Profil" data-en="LinkedIn Profile">LinkedIn Profil</a>
           <a class="btn btn-ghost" href="cv/Philipp_Kirr_CV.pdf" target="_blank" rel="noopener" data-de="Lebenslauf (PDF)" data-en="Resume (PDF)">Lebenslauf (PDF)</a>
+          <a class="btn btn-ghost" href="ukraine-moldawien-grenze.html" data-de="Blog" data-en="Blog">Blog</a>
         </div>
       </div>
     </header>

--- a/ukraine-moldawien-grenze.html
+++ b/ukraine-moldawien-grenze.html
@@ -1,0 +1,66 @@
+<!doctype html>
+<html lang="de">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Grenzerfahrung an der Ukraine-Moldawien-Grenze</title>
+  <meta name="description" content="Reisebericht: Grenzerfahrung an der Ukraine-Moldawien-Grenze." />
+  <meta property="og:title" content="Grenzerfahrung an der Ukraine-Moldawien-Grenze" />
+  <meta property="og:description" content="Ein Reisebericht über Schikane an der Grenze zur Republik Moldau." />
+  <meta property="og:type" content="article" />
+  <meta property="og:image" content="DSC_1961x.jpg" />
+  <style>
+    body{font-family:system-ui, sans-serif;max-width:800px;margin:40px auto;padding:0 16px;line-height:1.6;color:#1e293b}
+    h1{font-size:2rem;margin-bottom:.5rem}
+    h2{margin-top:2rem}
+    em{color:#475569}
+    #view-count-wrap{margin-top:2rem;font-weight:bold}
+  </style>
+</head>
+<body>
+  <article>
+    <h1>Grenzerfahrung an der Ukraine-Moldawien-Grenze: Wenn Kontrolle zur Schikane wird</h1>
+    <p><em>Ein Reisebericht mit bitterem Beigeschmack</em></p>
+    <p>Jedes Jahr reisen wir mit dem Auto durch Südeuropa. Rumänien, Moldawien – stets freundlich, effizient und korrekt. Dieses Jahr verlief selbst die Einreise von Polen in die Ukraine sehr angenehm: freundliche Beamte, schnelle Abfertigung, keinerlei Probleme. Auch die Durchfahrt durch die Ukraine war sehr positiv – nette Menschen, hilfsbereit, offen.</p>
+    <p>Doch an der Grenze zur Republik Moldau erlebten wir eine zutiefst frustrierende Situation, die wir nicht länger still hinnehmen wollen.</p>
+    <h2>Die Kontrolle: von Pflicht zur Willkür</h2>
+    <p>Am Grenzübergang zur Ukraine, gegen Mitternacht, waren wir das einzige Fahrzeug. Die Kontrolle – durch einen jungen Beamten – begann mit scheinbar routinemäßigen Fragen. Doch schnell wurde klar: es ging nicht um Sicherheit, sondern um Macht und Schikane.</p>
+    <p>Warum wir drei Laptops dabeihaben. Wozu so viele persönliche Gegenstände. Warum wir Wasser, Pflegeprodukte und Hygieneartikel transportieren. Fragen, die weder rechtlich notwendig noch sachlich begründet waren. Unsere Erklärungen stießen auf Desinteresse. Stattdessen: ein spöttischer Ton, anhaltende Verzögerung, unterschwellige Witze gegenüber meiner Frau.</p>
+    <p>Erst als sie dem Beamten mitteilte, dass sie für eine internationale Anwaltskanzlei mit Schwerpunkt auf Steuer- und Betrugsbekämpfung arbeitet, änderte sich die Haltung schlagartig. Plötzlich war Eile geboten, Papiere wurden abgestempelt, wir durften fahren.</p>
+    <h2>Keine Einzelfälle, sondern ein Muster</h2>
+    <p>Dies war nicht unser erster Vorfall an der ukrainischen Grenze zur Republik Moldau. Was bleibt, ist das Gefühl, dass es dort weniger um Sicherheit als um Erpressung und Einschüchterung geht. In anderen Ländern wurden wir nie so behandelt. Die Ukraine jedoch scheint bestimmte Beamte an ihren Grenzen völlig ohne Aufsicht oder klare Regeln agieren zu lassen.</p>
+    <h2>Unsere Stimme als Unterstützer der Ukraine</h2>
+    <p>Wir unterstützen die Ukraine seit Jahren, auch indirekt über unsere deutschen Steuergelder. Milliardenhilfen fließen in den Wiederaufbau, in humanitäre Hilfe, in Waffen, in Infrastruktur. Und doch erleben wir als Bürger genau dieses Landes, das uns als Freund sieht, diese Form der Behandlung?</p>
+    <p>Wir sind keine Schmuggler. Wir sind keine Bedrohung. Wir sind Besucher mit Respekt und guten Absichten. Aber genau so werden wir an dieser Grenze nicht behandelt.</p>
+    <h2>Was wir fordern</h2>
+    <ul>
+      <li>Aufklärung und Kontrolle der Grenzbeamten</li>
+      <li>Schulung im Umgang mit internationalen Besuchern</li>
+      <li>Transparente Regeln, auf die sich Reisende berufen können</li>
+      <li>Möglichkeit zur Beschwerde in einer Form, die auch Wirkung zeigt</li>
+    </ul>
+    <h2>Fazit</h2>
+    <p>Solche Erlebnisse zerstören Vertrauen. Und Vertrauen ist das Wertvollste, was die Ukraine gegenüber ihren internationalen Partnern hat.</p>
+    <p>Wir schweigen nicht länger. Und wir hoffen, dass wir nicht die Einzigen sind.</p>
+  </article>
+  <div id="view-count-wrap">Besucherzähler: <span id="view-count">0</span></div>
+  <section id="comments">
+    <h2>Kommentare</h2>
+    <script src="https://utteranc.es/client.js"
+            repo="stylex89/stylex89.github.io"
+            issue-term="pathname"
+            label="comment"
+            theme="github-light"
+            crossorigin="anonymous"
+            async>
+    </script>
+  </section>
+  <script>
+    fetch('https://api.countapi.xyz/hit/stylex89.github.io/grenzpost')
+      .then(res => res.json())
+      .then(res => {
+        document.getElementById('view-count').textContent = res.value;
+      });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add blog post about Ukraine-Moldova border experience with visitor counter and comment section
- link blog post from main page

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b3f655f4b48321bb1446d18f900b09