### PR TITLE
Integrate Cactus Comments for anonymous posting

### DIFF
--- a/ukraine-moldawien-grenze.html
+++ b/ukraine-moldawien-grenze.html
@@ -15,7 +15,10 @@
     h2{margin-top:2rem}
     em{color:#475569}
     #view-count-wrap{margin-top:2rem;font-weight:bold}
+    #cactus-comments{margin-top:1rem}
+    #cactus-comments *{font-family:inherit}
   </style>
+  <link rel="stylesheet" href="https://latest.cactus.chat/style.css" />
 </head>
 <body>
   <article>
@@ -46,15 +49,18 @@
   <div id="view-count-wrap">Besucherzähler: <span id="view-count">0</span></div>
   <section id="comments">
     <h2>Kommentare</h2>
-    <script src="https://utteranc.es/client.js"
-            repo="stylex89/stylex89.github.io"
-            issue-term="pathname"
-            label="comment"
-            theme="github-light"
-            crossorigin="anonymous"
-            async>
-    </script>
+    <div id="cactus-comments"></div>
   </section>
+  <script type="module">
+    import initComments from 'https://latest.cactus.chat/cactus.js';
+    initComments({
+      serverName: 'cactus.chat',
+      siteName: 'stylex89.github.io',
+      roomName: 'ukraine-moldawien-grenze',
+      defaultHomeserverUrl: 'https://matrix-client.matrix.org',
+      element: document.getElementById('cactus-comments')
+    });
+  </script>
   <script>
     fetch('https://api.countapi.xyz/hit/stylex89.github.io/grenzpost')
       .then(res => res.json())


### PR DESCRIPTION
## Summary
- replace GitHub-based Utterances widget with Cactus Comments to allow anonymous discussions
- add basic CSS to match site typography

## Testing
- `npm test` *(fails: Could not read package.json)*
- `curl -I https://latest.cactus.chat/cactus.js` *(fails: CONNECT tunnel failed, response 403)*
- `python3 -m http.server 8000 &` `curl -s http://localhost:8000/ukraine-moldawien-grenze.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68b4003c4968832197288af527231c2b