### PR TITLE
Refactor CSS into shared stylesheet and apply to blog page

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,71 +10,7 @@
   <meta property="og:type" content="website" />
   <meta property="og:image" content="DSC_1961x.jpg" />
   <meta name="theme-color" content="#0ea5e9" />
-  <style>
-    :root{
-      --bg:#0b1020; --panel:#0f172a; --muted:#94a3b8; --text:#e5edf7;
-      --accent:#22d3ee; --accent-2:#38bdf8; --success:#34d399; --chip:#132238; --ring: rgba(56,189,248,.35);
-    }
-    *{box-sizing:border-box}
-    html,body{margin:0;height:100%;background:radial-gradient(1100px 700px at 10% -10%,rgba(56,189,248,.20),transparent),
-                               radial-gradient(900px 600px at 110% -30%,rgba(34,211,238,.12),transparent),var(--bg);
-               color:var(--text);font:500 16px/1.6 "Inter",system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Arial,sans-serif;scroll-behavior:smooth}
-    a{color:var(--accent);text-decoration:none}
-    .container{max-width:1040px;margin:0 auto;padding:24px;position:relative}
-    .glow{position:absolute;inset:-200px -140px auto auto;pointer-events:none;filter:blur(50px);opacity:.3;
-          background:conic-gradient(from 180deg at 50% 50%, rgba(34,211,238,.35), transparent 45%, rgba(56,189,248,.4), transparent 70%, rgba(34,211,238,.35));
-          width:520px;height:520px;border-radius:50%;animation:slowspin 22s linear infinite}
-    @keyframes slowspin{to{transform:rotate(360deg)}}
-
-    header{display:flex;flex-wrap:wrap;gap:24px;align-items:center;margin:28px 0 36px;position:relative}
-    .langswitch{position:absolute;right:0;top:-8px;display:flex;gap:8px}
-    .langswitch button{background:transparent;border:1px solid #1e293b;color:var(--text);padding:6px 12px;border-radius:999px;cursor:pointer;font-weight:700;letter-spacing:.4px}
-    .langswitch button.active{background:linear-gradient(135deg,var(--accent),var(--accent-2));color:#06121f;box-shadow:0 8px 30px -12px var(--ring)}
-
-    .avatar-wrap{position:relative;flex-shrink:0}
-    .avatar-wrap:before{content:"";position:absolute;inset:-6px;z-index:0;border-radius:26px;filter:blur(6px);
-      background:conic-gradient(from 0deg, var(--accent), var(--accent-2), var(--success), var(--accent));animation:huerotate 8s linear infinite}
-    @keyframes huerotate{to{filter:hue-rotate(360deg) blur(6px)}}
-    .avatar{position:relative;z-index:1;width:128px;height:128px;border-radius:24px;background:#111 center/cover no-repeat url('DSC_1961x.jpg');
-            box-shadow:0 0 0 6px rgba(56,189,248,.12), 0 18px 46px -14px rgba(2,132,199,.55);animation:float 6s ease-in-out infinite}
-    @keyframes float{0%,100%{transform:translateY(0)}50%{transform:translateY(-6px)}}
-
-    .title h1{margin:0;font-size:clamp(30px,5vw,44px);font-weight:800;letter-spacing:.2px}
-    .title p{margin:6px 0 0;color:var(--muted);font-size:18px}
-    .chips{display:flex;flex-wrap:wrap;gap:8px;margin-top:12px}
-    .chip{background:linear-gradient(180deg,var(--chip),#0c1426);color:#cbd5e1;padding:6px 12px;border:1px solid #0b1a2e;border-radius:999px;font-size:13px}
-    .chip-available{background:linear-gradient(180deg,rgba(52,211,153,.15),rgba(15,118,110,.22));border-color:rgba(16,185,129,.45);color:#c7f9e5}
-
-    .cta{display:flex;flex-wrap:wrap;gap:12px;margin-top:16px}
-    .btn{border:none;border-radius:12px;padding:12px 16px;font-weight:700;cursor:pointer;transition:transform .15s ease, box-shadow .15s ease}
-    .btn-primary{background:linear-gradient(135deg,var(--accent),var(--accent-2));color:#06121f;box-shadow:0 12px 32px -12px var(--ring)}
-    .btn-primary:hover{transform:translateY(-2px)}
-    .btn-ghost{background:transparent;border:1px solid #1e293b;color:var(--text)}
-
-    .grid{display:grid;gap:18px}
-    @media(min-width:860px){.grid{grid-template-columns:1.1fr .9fr}}
-    section{background:linear-gradient(180deg,rgba(148,163,184,.08),transparent);border:1px solid rgba(148,163,184,.10);
-            border-radius:16px;padding:20px;margin:10px 0;backdrop-filter:saturate(1.1) blur(2px);transform:translateY(6px);opacity:0}
-    section.reveal{transform:translateY(0);opacity:1;transition:opacity .6s ease, transform .6s ease}
-    h2{margin:0 0 8px;font-size:22px}
-    ul{margin:10px 0 0;padding-left:18px}
-    .list>li{margin-bottom:8px}
-    .timeline{position:relative;padding-left:22px}
-    .timeline:before{content:"";position:absolute;left:8px;top:0;bottom:0;width:2px;background:linear-gradient(var(--accent),transparent)}
-    .tl-item{position:relative;margin-bottom:14px}
-    .tl-item:before{content:"";position:absolute;left:-18px;top:6px;width:10px;height:10px;border-radius:50%;background:var(--accent);box-shadow:0 0 0 4px rgba(34,211,238,.18)}
-
-    .kpi{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:10px;margin-top:8px}
-    .kpi>div{background:rgba(2,6,23,.5);border:1px solid rgba(148,163,184,.12);border-radius:14px;padding:10px;text-align:center}
-    .kpi strong{display:block;font-size:22px}
-    footer{color:var(--muted);text-align:center;margin:30px 0}
-    .small{font-size:14px;color:var(--muted)}
-
-    @media (prefers-reduced-motion: reduce){
-      .glow,.avatar{animation:none}
-      section{transition:none}
-    }
-  </style>
+  <link rel="stylesheet" href="style.css" />
 </head>
 <body>
   <div class="container">

--- a/style.css
+++ b/style.css
@@ -1,0 +1,70 @@
+:root{
+  --bg:#0b1020; --panel:#0f172a; --muted:#94a3b8; --text:#e5edf7;
+  --accent:#22d3ee; --accent-2:#38bdf8; --success:#34d399; --chip:#132238; --ring: rgba(56,189,248,.35);
+}
+*{box-sizing:border-box}
+html,body{margin:0;height:100%;background:radial-gradient(1100px 700px at 10% -10%,rgba(56,189,248,.20),transparent),
+                             radial-gradient(900px 600px at 110% -30%,rgba(34,211,238,.12),transparent),var(--bg);
+             color:var(--text);font:500 16px/1.6 "Inter",system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Arial,sans-serif;scroll-behavior:smooth}
+a{color:var(--accent);text-decoration:none}
+.container{max-width:1040px;margin:0 auto;padding:24px;position:relative}
+.glow{position:absolute;inset:-200px -140px auto auto;pointer-events:none;filter:blur(50px);opacity:.3;
+      background:conic-gradient(from 180deg at 50% 50%, rgba(34,211,238,.35), transparent 45%, rgba(56,189,248,.4), transparent 70%, rgba(34,211,238,.35));
+      width:520px;height:520px;border-radius:50%;animation:slowspin 22s linear infinite}
+@keyframes slowspin{to{transform:rotate(360deg)}}
+
+header{display:flex;flex-wrap:wrap;gap:24px;align-items:center;margin:28px 0 36px;position:relative}
+.langswitch{position:absolute;right:0;top:-8px;display:flex;gap:8px}
+.langswitch button{background:transparent;border:1px solid #1e293b;color:var(--text);padding:6px 12px;border-radius:999px;cursor:pointer;font-weight:700;letter-spacing:.4px}
+.langswitch button.active{background:linear-gradient(135deg,var(--accent),var(--accent-2));color:#06121f;box-shadow:0 8px 30px -12px var(--ring)}
+
+.avatar-wrap{position:relative;flex-shrink:0}
+.avatar-wrap:before{content:"";position:absolute;inset:-6px;z-index:0;border-radius:26px;filter:blur(6px);
+  background:conic-gradient(from 0deg, var(--accent), var(--accent-2), var(--success), var(--accent));animation:huerotate 8s linear infinite}
+@keyframes huerotate{to{filter:hue-rotate(360deg) blur(6px)}}
+.avatar{position:relative;z-index:1;width:128px;height:128px;border-radius:24px;background:#111 center/cover no-repeat url('DSC_1961x.jpg');
+        box-shadow:0 0 0 6px rgba(56,189,248,.12), 0 18px 46px -14px rgba(2,132,199,.55);animation:float 6s ease-in-out infinite}
+@keyframes float{0%,100%{transform:translateY(0)}50%{transform:translateY(-6px)}}
+
+.title h1{margin:0;font-size:clamp(30px,5vw,44px);font-weight:800;letter-spacing:.2px}
+.title p{margin:6px 0 0;color:var(--muted);font-size:18px}
+.chips{display:flex;flex-wrap:wrap;gap:8px;margin-top:12px}
+.chip{background:linear-gradient(180deg,var(--chip),#0c1426);color:#cbd5e1;padding:6px 12px;border:1px solid #0b1a2e;border-radius:999px;font-size:13px}
+.chip-available{background:linear-gradient(180deg,rgba(52,211,153,.15),rgba(15,118,110,.22));border-color:rgba(16,185,129,.45);color:#c7f9e5}
+
+.cta{display:flex;flex-wrap:wrap;gap:12px;margin-top:16px}
+.btn{border:none;border-radius:12px;padding:12px 16px;font-weight:700;cursor:pointer;transition:transform .15s ease, box-shadow .15s ease}
+.btn-primary{background:linear-gradient(135deg,var(--accent),var(--accent-2));color:#06121f;box-shadow:0 12px 32px -12px var(--ring)}
+.btn-primary:hover{transform:translateY(-2px)}
+.btn-ghost{background:transparent;border:1px solid #1e293b;color:var(--text)}
+
+.grid{display:grid;gap:18px}
+@media(min-width:860px){.grid{grid-template-columns:1.1fr .9fr}}
+section{background:linear-gradient(180deg,rgba(148,163,184,.08),transparent);border:1px solid rgba(148,163,184,.10);
+        border-radius:16px;padding:20px;margin:10px 0;backdrop-filter:saturate(1.1) blur(2px);transform:translateY(6px);opacity:0}
+section.reveal{transform:translateY(0);opacity:1;transition:opacity .6s ease, transform .6s ease}
+h2{margin:0 0 8px;font-size:clamp(20px,4vw,24px)}
+ul{margin:10px 0 0;padding-left:18px}
+.list>li{margin-bottom:8px}
+.timeline{position:relative;padding-left:22px}
+.timeline:before{content:"";position:absolute;left:8px;top:0;bottom:0;width:2px;background:linear-gradient(var(--accent),transparent)}
+.tl-item{position:relative;margin-bottom:14px}
+.tl-item:before{content:"";position:absolute;left:-18px;top:6px;width:10px;height:10px;border-radius:50%;background:var(--accent);box-shadow:0 0 0 4px rgba(34,211,238,.18)}
+
+.kpi{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:10px;margin-top:8px}
+.kpi>div{background:rgba(2,6,23,.5);border:1px solid rgba(148,163,184,.12);border-radius:14px;padding:10px;text-align:center}
+.kpi strong{display:block;font-size:22px}
+footer{color:var(--muted);text-align:center;margin:30px 0}
+.small{font-size:14px;color:var(--muted)}
+em{color:var(--muted)}
+
+@media (prefers-reduced-motion: reduce){
+  .glow,.avatar{animation:none}
+  section{transition:none}
+}
+
+/* Article specific */
+article{max-width:800px;margin:0 auto}
+article h1{margin:0 0 12px;font-size:clamp(26px,4vw,36px);line-height:1.3}
+article h2{margin-top:32px;font-size:clamp(22px,3.5vw,28px)}
+#view-count-wrap{margin-top:32px;font-weight:bold}

--- a/ukraine-moldawien-grenze.html
+++ b/ukraine-moldawien-grenze.html
@@ -9,53 +9,57 @@
   <meta property="og:description" content="Ein Reisebericht über Schikane an der Grenze zur Republik Moldau." />
   <meta property="og:type" content="article" />
   <meta property="og:image" content="DSC_1961x.jpg" />
-  <style>
-    body{font-family:system-ui, sans-serif;max-width:800px;margin:40px auto;padding:0 16px;line-height:1.6;color:#1e293b}
-    h1{font-size:2rem;margin-bottom:.5rem}
-    h2{margin-top:2rem}
-    em{color:#475569}
-    #view-count-wrap{margin-top:2rem;font-weight:bold}
-  </style>
+  <link rel="stylesheet" href="style.css" />
 </head>
 <body>
-  <article>
-    <h1>Grenzerfahrung an der Ukraine-Moldawien-Grenze: Wenn Kontrolle zur Schikane wird</h1>
-    <p><em>Ein Reisebericht mit bitterem Beigeschmack</em></p>
-    <p>Jedes Jahr reisen wir mit dem Auto durch Südeuropa. Rumänien, Moldawien – stets freundlich, effizient und korrekt. Dieses Jahr verlief selbst die Einreise von Polen in die Ukraine sehr angenehm: freundliche Beamte, schnelle Abfertigung, keinerlei Probleme. Auch die Durchfahrt durch die Ukraine war sehr positiv – nette Menschen, hilfsbereit, offen.</p>
-    <p>Doch an der Grenze zur Republik Moldau erlebten wir eine zutiefst frustrierende Situation, die wir nicht länger still hinnehmen wollen.</p>
-    <h2>Die Kontrolle: von Pflicht zur Willkür</h2>
-    <p>Am Grenzübergang zur Ukraine, gegen Mitternacht, waren wir das einzige Fahrzeug. Die Kontrolle – durch einen jungen Beamten – begann mit scheinbar routinemäßigen Fragen. Doch schnell wurde klar: es ging nicht um Sicherheit, sondern um Macht und Schikane.</p>
-    <p>Warum wir drei Laptops dabeihaben. Wozu so viele persönliche Gegenstände. Warum wir Wasser, Pflegeprodukte und Hygieneartikel transportieren. Fragen, die weder rechtlich notwendig noch sachlich begründet waren. Unsere Erklärungen stießen auf Desinteresse. Stattdessen: ein spöttischer Ton, anhaltende Verzögerung, unterschwellige Witze gegenüber meiner Frau.</p>
-    <p>Erst als sie dem Beamten mitteilte, dass sie für eine internationale Anwaltskanzlei mit Schwerpunkt auf Steuer- und Betrugsbekämpfung arbeitet, änderte sich die Haltung schlagartig. Plötzlich war Eile geboten, Papiere wurden abgestempelt, wir durften fahren.</p>
-    <h2>Keine Einzelfälle, sondern ein Muster</h2>
-    <p>Dies war nicht unser erster Vorfall an der ukrainischen Grenze zur Republik Moldau. Was bleibt, ist das Gefühl, dass es dort weniger um Sicherheit als um Erpressung und Einschüchterung geht. In anderen Ländern wurden wir nie so behandelt. Die Ukraine jedoch scheint bestimmte Beamte an ihren Grenzen völlig ohne Aufsicht oder klare Regeln agieren zu lassen.</p>
-    <h2>Unsere Stimme als Unterstützer der Ukraine</h2>
-    <p>Wir unterstützen die Ukraine seit Jahren, auch indirekt über unsere deutschen Steuergelder. Milliardenhilfen fließen in den Wiederaufbau, in humanitäre Hilfe, in Waffen, in Infrastruktur. Und doch erleben wir als Bürger genau dieses Landes, das uns als Freund sieht, diese Form der Behandlung?</p>
-    <p>Wir sind keine Schmuggler. Wir sind keine Bedrohung. Wir sind Besucher mit Respekt und guten Absichten. Aber genau so werden wir an dieser Grenze nicht behandelt.</p>
-    <h2>Was wir fordern</h2>
-    <ul>
-      <li>Aufklärung und Kontrolle der Grenzbeamten</li>
-      <li>Schulung im Umgang mit internationalen Besuchern</li>
-      <li>Transparente Regeln, auf die sich Reisende berufen können</li>
-      <li>Möglichkeit zur Beschwerde in einer Form, die auch Wirkung zeigt</li>
-    </ul>
-    <h2>Fazit</h2>
-    <p>Solche Erlebnisse zerstören Vertrauen. Und Vertrauen ist das Wertvollste, was die Ukraine gegenüber ihren internationalen Partnern hat.</p>
-    <p>Wir schweigen nicht länger. Und wir hoffen, dass wir nicht die Einzigen sind.</p>
-  </article>
-  <div id="view-count-wrap">Besucherzähler: <span id="view-count">0</span></div>
-  <section id="comments">
-    <h2>Kommentare</h2>
-    <script src="https://utteranc.es/client.js"
-            repo="stylex89/stylex89.github.io"
-            issue-term="pathname"
-            label="comment"
-            theme="github-light"
-            crossorigin="anonymous"
-            async>
-    </script>
-  </section>
+  <div class="container">
+    <header>
+      <div class="title">
+        <h1>Grenzerfahrung an der Ukraine-Moldawien-Grenze: Wenn Kontrolle zur Schikane wird</h1>
+        <p><em>Ein Reisebericht mit bitterem Beigeschmack</em></p>
+      </div>
+    </header>
+    <article>
+      <p>Jedes Jahr reisen wir mit dem Auto durch Südeuropa. Rumänien, Moldawien – stets freundlich, effizient und korrekt. Dieses Jahr verlief selbst die Einreise von Polen in die Ukraine sehr angenehm: freundliche Beamte, schnelle Abfertigung, keinerlei Probleme. Auch die Durchfahrt durch die Ukraine war sehr positiv – nette Menschen, hilfsbereit, offen.</p>
+      <p>Doch an der Grenze zur Republik Moldau erlebten wir eine zutiefst frustrierende Situation, die wir nicht länger still hinnehmen wollen.</p>
+      <h2>Die Kontrolle: von Pflicht zur Willkür</h2>
+      <p>Am Grenzübergang zur Ukraine, gegen Mitternacht, waren wir das einzige Fahrzeug. Die Kontrolle – durch einen jungen Beamten – begann mit scheinbar routinemäßigen Fragen. Doch schnell wurde klar: es ging nicht um Sicherheit, sondern um Macht und Schikane.</p>
+      <p>Warum wir drei Laptops dabeihaben. Wozu so viele persönliche Gegenstände. Warum wir Wasser, Pflegeprodukte und Hygieneartikel transportieren. Fragen, die weder rechtlich notwendig noch sachlich begründet waren. Unsere Erklärungen stießen auf Desinteresse. Stattdessen: ein spöttischer Ton, anhaltende Verzögerung, unterschwellige Witze gegenüber meiner Frau.</p>
+      <p>Erst als sie dem Beamten mitteilte, dass sie für eine internationale Anwaltskanzlei mit Schwerpunkt auf Steuer- und Betrugsbekämpfung arbeitet, änderte sich die Haltung schlagartig. Plötzlich war Eile geboten, Papiere wurden abgestempelt, wir durften fahren.</p>
+      <h2>Keine Einzelfälle, sondern ein Muster</h2>
+      <p>Dies war nicht unser erster Vorfall an der ukrainischen Grenze zur Republik Moldau. Was bleibt, ist das Gefühl, dass es dort weniger um Sicherheit als um Erpressung und Einschüchterung geht. In anderen Ländern wurden wir nie so behandelt. Die Ukraine jedoch scheint bestimmte Beamte an ihren Grenzen völlig ohne Aufsicht oder klare Regeln agieren zu lassen.</p>
+      <h2>Unsere Stimme als Unterstützer der Ukraine</h2>
+      <p>Wir unterstützen die Ukraine seit Jahren, auch indirekt über unsere deutschen Steuergelder. Milliardenhilfen fließen in den Wiederaufbau, in humanitäre Hilfe, in Waffen, in Infrastruktur. Und doch erleben wir als Bürger genau dieses Landes, das uns als Freund sieht, diese Form der Behandlung?</p>
+      <p>Wir sind keine Schmuggler. Wir sind keine Bedrohung. Wir sind Besucher mit Respekt und guten Absichten. Aber genau so werden wir an dieser Grenze nicht behandelt.</p>
+      <h2>Was wir fordern</h2>
+      <ul>
+        <li>Aufklärung und Kontrolle der Grenzbeamten</li>
+        <li>Schulung im Umgang mit internationalen Besuchern</li>
+        <li>Transparente Regeln, auf die sich Reisende berufen können</li>
+        <li>Möglichkeit zur Beschwerde in einer Form, die auch Wirkung zeigt</li>
+      </ul>
+      <h2>Fazit</h2>
+      <p>Solche Erlebnisse zerstören Vertrauen. Und Vertrauen ist das Wertvollste, was die Ukraine gegenüber ihren internationalen Partnern hat.</p>
+      <p>Wir schweigen nicht länger. Und wir hoffen, dass wir nicht die Einzigen sind.</p>
+    </article>
+    <div id="view-count-wrap">Besucherzähler: <span id="view-count">0</span></div>
+    <section id="comments">
+      <h2>Kommentare</h2>
+      <script src="https://utteranc.es/client.js"
+              repo="stylex89/stylex89.github.io"
+              issue-term="pathname"
+              label="comment"
+              theme="github-light"
+              crossorigin="anonymous"
+              async>
+      </script>
+    </section>
+    <footer>
+      <p class="small">© <span id="y"></span> Philipp Kirr · <a href="index.html">Startseite</a></p>
+    </footer>
+  </div>
   <script>
+    document.getElementById('y').textContent=new Date().getFullYear();
     fetch('https://api.countapi.xyz/hit/stylex89.github.io/grenzpost')
       .then(res => res.json())
       .then(res => {


### PR DESCRIPTION
## Summary
- Move inline styles from `index.html` into new `style.css` for reuse
- Load the shared stylesheet on the blog article and wrap content with site container/header/footer
- Add responsive heading and article spacing for better mobile/desktop typography

## Testing
- `npx -y htmlhint index.html ukraine-moldawien-grenze.html` (fails: 403 Forbidden)
- `apt-get update` (fails: repository access 403)


------
https://chatgpt.com/codex/tasks/task_e_68b4003b43c8832195d85a0392675a35